### PR TITLE
開始日と期限日追加に伴う軽微な修正

### DIFF
--- a/resources/js/Components/DateInput.tsx
+++ b/resources/js/Components/DateInput.tsx
@@ -1,26 +1,30 @@
-import React, { forwardRef, InputHTMLAttributes, useRef, useImperativeHandle, useEffect } from 'react';
-import 'react-datepicker/dist/react-datepicker.css';
-import { DateInputProps } from '@/types';
+import "react-datepicker/dist/react-datepicker.css";
 
-import DatePicker from 'react-datepicker';
+import { ja } from "date-fns/locale";
+import React, { forwardRef } from "react";
+import DatePicker, { registerLocale } from "react-datepicker";
+
+import { DateInputProps } from "@/types";
 
 const DateInput = forwardRef<DatePicker, DateInputProps>(
-    ({ selected, onChange, className}, ref) => {
+    ({ selected, onChange, className }, ref) => {
         const Today = new Date();
+        registerLocale("ja", ja);
 
         return (
             <DatePicker
-            selected={selected ?? undefined} // `null` を `undefined` に変換
-            onChange={date => onChange(date)}
-            ref={ref as React.RefObject<DatePicker>} // RefObject<DatePicker> にキャスト
-            dateFormat="yyyy/MM/dd"
-            minDate={Today}
-            className={`border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm block w-full ${className}`}
-        />
+                selected={selected ?? undefined} // `null` を `undefined` に変換
+                onChange={(date) => onChange(date)}
+                ref={ref as React.RefObject<DatePicker>} // RefObject<DatePicker> にキャスト
+                dateFormat="yyyy/MM/dd"
+                locale="ja"
+                minDate={Today}
+                className={`border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm block w-full ${className}`}
+            />
         );
     }
 );
 
-DateInput.displayName = 'DateInput';
+DateInput.displayName = "DateInput";
 
 export default DateInput;

--- a/resources/js/Pages/Todo/Index.tsx
+++ b/resources/js/Pages/Todo/Index.tsx
@@ -1,17 +1,16 @@
-import { FormEventHandler, useEffect, useRef, useState } from 'react';
+import { FormEventHandler, useEffect, useRef, useState } from "react";
 
-import DangerButton from '@/Components/DangerButton';
-import EditButton from '@/Components/EditButton';
-import Modal from '@/Components/Modal';
-import PrimaryButton from '@/Components/PrimaryButton';
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { PageProps, Todo } from '@/types';
-import { Head, Link, useForm, usePage } from '@inertiajs/react';
+import DangerButton from "@/Components/DangerButton";
+import EditButton from "@/Components/EditButton";
+import Modal from "@/Components/Modal";
+import PrimaryButton from "@/Components/PrimaryButton";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import { PageProps, Todo } from "@/types";
+import { Head, Link, useForm, usePage } from "@inertiajs/react";
 
-import TodoForm from './Modal/TodoForm';
+import TodoForm from "./Modal/TodoForm";
 
 export default function todoIndex({ auth, todos, message }: PageProps) {
-
     // Todo一覧の型宣言
     const todoLists = todos as Todo[];
     // Todo作成・編集のステータス
@@ -65,7 +64,7 @@ export default function todoIndex({ auth, todos, message }: PageProps) {
         description: string,
         is_completed: boolean,
         start_date: Date,
-        due_date: Date,
+        due_date: Date
     ) => {
         reset();
         setData({
@@ -73,8 +72,8 @@ export default function todoIndex({ auth, todos, message }: PageProps) {
             title: title,
             description: description,
             is_completed: is_completed,
-            start_date: start_date, 
-            due_date: due_date, 
+            start_date: start_date,
+            due_date: due_date,
         });
         // バリデーションエラーメッセージをクリア
         errors.title = "";
@@ -152,6 +151,8 @@ export default function todoIndex({ auth, todos, message }: PageProps) {
         // バリデーションエラーメッセージをクリア
         errors.title = "";
         errors.description = "";
+        errors.start_date = "";
+        errors.due_date = "";
     };
 
     // Todo編集モーダルのキャンセルボタン押下時
@@ -169,6 +170,8 @@ export default function todoIndex({ auth, todos, message }: PageProps) {
         // バリデーションエラーメッセージをクリア
         errors.title = "";
         errors.description = "";
+        errors.start_date = "";
+        errors.due_date = "";
     };
 
     // フラッシュメッセージの表示・非表示


### PR DESCRIPTION
・キャンセルボタン押下後のバリデーションメッセージのクリア
・作成・編集フォームで開始日と期限日を選択するカレンダーを日本語表記に変更